### PR TITLE
Add sitemap and robots txt for SEO

### DIFF
--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -3,9 +3,36 @@ import './globals.css'
 import AuthProvider from '@/components/auth/auth-provider'
 import { getServerAuthSession } from '@/lib/auth'
 
+const siteUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+
 export const metadata: Metadata = {
   title: 'Tender Tales - Satellite Change Detection Platform',
   description: 'Visualizing environmental change through Google Earth Engine satellite data. Detect and monitor changes in forest cover, urban development, and land use with AI-powered analysis.',
+  keywords: 'satellite imagery, environmental monitoring, Google Earth Engine, AI, conservation, ocean health, change detection',
+  robots: 'index, follow',
+  metadataBase: new URL(siteUrl),
+  openGraph: {
+    title: 'Tender Tales - Satellite Change Detection Platform',
+    description: 'Visualizing environmental change through Google Earth Engine satellite data. Detect and monitor changes in forest cover, urban development, and land use with AI-powered analysis.',
+    url: siteUrl,
+    siteName: 'Tender Tales',
+    images: [
+      {
+        url: '/tender-tales-logo.png',
+        width: 1200,
+        height: 630,
+        alt: 'Tender Tales Logo',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Tender Tales - Satellite Change Detection Platform',
+    description: 'Visualizing environmental change through Google Earth Engine satellite data. Detect and monitor changes in forest cover, urban development, and land use with AI-powered analysis.',
+    images: ['/tender-tales-logo.png'],
+  },
   icons: {
     icon: [
       { url: '/favicon.ico', sizes: '32x32', type: 'image/x-icon' },

--- a/ui/src/app/robots.txt/route.ts
+++ b/ui/src/app/robots.txt/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  const siteUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+
+  const robotsTxt = `User-agent: *
+Allow: /
+
+# Sitemap location
+Sitemap: ${siteUrl}/sitemap.xml`
+
+  return new NextResponse(robotsTxt, {
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  })
+}

--- a/ui/src/app/sitemap.xml/route.ts
+++ b/ui/src/app/sitemap.xml/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  const siteUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const currentDate = new Date().toISOString()
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>${siteUrl}/</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>${siteUrl}/about</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>${siteUrl}/blog</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>${siteUrl}/blog/whale-ship-strikes</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>${siteUrl}/contact</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>${siteUrl}/services/conservation-partnership</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>${siteUrl}/services/pro-bono-consulting</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>${siteUrl}/privacy</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>${siteUrl}/terms</loc>
+    <lastmod>${currentDate}</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>`
+
+  return new NextResponse(sitemap, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  })
+}


### PR DESCRIPTION
This pull request adds significant improvements to the site's SEO and discoverability by enhancing metadata, and by introducing dynamic generation of `robots.txt` and `sitemap.xml` endpoints. These changes help search engines better understand and index the site, and ensure that metadata is consistently set across different environments.

**SEO and Metadata Enhancements:**

* Expanded the `metadata` object in `layout.tsx` to include keywords, robots directives, Open Graph, and Twitter card metadata, all dynamically using the site URL from environment variables.

**Dynamic SEO Endpoint Generation:**

* Added a new `robots.txt` API route that generates a robots.txt file dynamically based on the current site URL, including a reference to the sitemap location.
* Added a new `sitemap.xml` API route that generates a sitemap with all key site pages, using the current date and the site URL from environment variables.