### PR TITLE
Restructure tests

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -90,7 +90,7 @@ jobs:
             -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json \
             -v $PWD/tender_tales/credentials.json:/app/credentials.json:ro \
             tender-tales/platform:mcp-server-${{ env.BUILD_ID }} \
-            sh -c "cd /app && uv run pytest tests/mcp_server/test_mcp_client.py::test_mcp_server -m integration -v"
+            sh -c "cd /app && uv run pytest tests/mcp_server/test_mcp_client.py::test_mcp_server -m integration -v --no-cov"
 
           # Test that the server can start successfully (run briefly)
           echo "=== Testing MCP Server Startup ==="

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -23,7 +23,7 @@ env:
   DEBUG: false
 
 jobs:
-  build-backend:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -90,7 +90,7 @@ jobs:
             -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json \
             -v $PWD/tender_tales/credentials.json:/app/credentials.json:ro \
             tender-tales/platform:mcp-server-${{ env.BUILD_ID }} \
-            sh -c "cd /app/mcp_server && uv run python test_mcp_client.py"
+            sh -c "cd /app && uv run pytest tests/mcp_server/test_mcp_client.py::test_mcp_server -m integration -v"
 
           # Test that the server can start successfully (run briefly)
           echo "=== Testing MCP Server Startup ==="
@@ -138,9 +138,25 @@ jobs:
           docker compose logs backend
           docker compose down
 
+      - name: Build frontend image
+        run: |
+          export COMPOSE_PROJECT_NAME=tender-tales-ci
+          export BACKEND_PORT=${{ env.BACKEND_PORT }}
+          export FRONTEND_PORT=${{ env.FRONTEND_PORT }}
+          export BACKEND_HOST=${{ env.BACKEND_HOST }}
+          export DEBUG=${{ env.DEBUG }}
+          export BUILD_ID=${{ env.BUILD_ID }}
+          docker compose build frontend \
+            --build-arg NEXT_PUBLIC_MAPBOX_API_KEY=${{ secrets.MAPBOX_API_KEY }} \
+            --build-arg NEXT_PUBLIC_BACKEND_URL=http://localhost:8000 \
+            --build-arg NEXTAUTH_SECRET=test-secret \
+            --build-arg GOOGLE_CLIENT_ID=test-client-id \
+            --build-arg GOOGLE_CLIENT_SECRET=test-client-secret \
+            --build-arg WEB3FORMS_ACCESS_KEY=test-web3forms-key
+
   deploy:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: build-backend
+    needs: build
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install dependencies and check code
         run: |
-          cd tender_tales && uv run pytest --cov=. --cov-report=xml tests
+          cd tender_tales && uv run pytest --cov=. --cov-report=xml tests -m "not integration"
 
       # Uncomment this once this repo is configured on Codecov
       - name: Upload coverage to Codecov

--- a/tender_tales/pyproject.toml
+++ b/tender_tales/pyproject.toml
@@ -39,7 +39,8 @@ packages = ["api/", "mcp_server/", "services/", "shared/"]
 
 [dependency-groups]
 dev = [
-    "pytest>=7.1.1",
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.1.0",
     "pre-commit>=4.0.0",
     "pytest-cov>=3.0.0",
     "codecov>=2.1.13",
@@ -144,6 +145,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+asyncio_mode = "auto"
 addopts = [
     "-v",
     "--tb=short",

--- a/tender_tales/pyproject.toml
+++ b/tender_tales/pyproject.toml
@@ -156,6 +156,9 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::UserWarning",
 ]
+markers = [
+    "integration: marks tests as integration tests",
+]
 
 [tool.coverage.run]
 source = ["api"]

--- a/tender_tales/tests/mcp_server/__init__.py
+++ b/tender_tales/tests/mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for MCP server."""

--- a/tender_tales/tests/mcp_server/test_mcp_client.py
+++ b/tender_tales/tests/mcp_server/test_mcp_client.py
@@ -6,7 +6,8 @@ import traceback
 
 import ee
 import pytest
-import tools
+
+from mcp_server import tools
 
 # Import only the config to avoid running the server
 from mcp_server.config import MCPConfig

--- a/tender_tales/tests/mcp_server/test_mcp_client.py
+++ b/tender_tales/tests/mcp_server/test_mcp_client.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-"""Simple MCP client test script to verify server functionality."""
+"""Integration test for MCP server functionality."""
 
 import asyncio
-import sys
 import traceback
 
 import ee
+import pytest
 import tools
 
 # Import only the config to avoid running the server
-from config import MCPConfig
+from mcp_server.config import MCPConfig
 
 
+@pytest.mark.integration
 async def test_mcp_server() -> None:
     """Test the MCP server components without running the server."""
     print("=== Testing MCP Server Functionality ===")
@@ -86,7 +87,7 @@ async def test_mcp_server() -> None:
     except Exception as e:
         print(f"✗ Test failed: {e}")
         traceback.print_exc()
-        sys.exit(1)
+        pytest.fail(f"MCP server integration test failed: {e}")
 
 
 if __name__ == "__main__":

--- a/tender_tales/tests/mcp_server/test_mcp_client.py
+++ b/tender_tales/tests/mcp_server/test_mcp_client.py
@@ -14,6 +14,7 @@ from mcp_server.config import MCPConfig
 
 
 @pytest.mark.integration
+@pytest.mark.asyncio
 async def test_mcp_server() -> None:
     """Test the MCP server components without running the server."""
     print("=== Testing MCP Server Functionality ===")

--- a/tender_tales/uv.lock
+++ b/tender_tales/uv.lock
@@ -1984,7 +1984,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1993,9 +1993,21 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]
@@ -2412,6 +2424,7 @@ dev = [
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -2454,7 +2467,8 @@ dev = [
     { name = "mypy", specifier = ">=1.7.0" },
     { name = "pip-audit", specifier = ">=2.7.1" },
     { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "pytest", specifier = ">=7.1.1" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov", specifier = ">=3.0.0" },
     { name = "ruff", specifier = ">=0.6.0" },
 ]

--- a/ui/src/app/kadal/page.tsx
+++ b/ui/src/app/kadal/page.tsx
@@ -295,6 +295,9 @@ function MapPageContent() {
     try {
       // Get current viewport bounds
       const bounds = mapRef.current.getBounds()
+      if (!bounds) {
+        throw new Error('Unable to get map bounds')
+      }
       const viewportBounds = {
         north: bounds.getNorth(),
         south: bounds.getSouth(),


### PR DESCRIPTION
This pull request introduces several improvements to the testing workflow and code organization, particularly around MCP server integration tests and CI configuration. The main changes include restructuring integration tests, refining CI test selection, and enhancing error handling and build steps.

**Testing and CI improvements:**

* The MCP server integration test script was moved from `tender_tales/mcp_server/test_mcp_client.py` to `tender_tales/tests/mcp_server/test_mcp_client.py`, rewritten to use `pytest` with the `integration` marker, and improved error handling by replacing `sys.exit(1)` with `pytest.fail` for better test reporting. [[1]](diffhunk://#diff-a1264851df883ea8a16a191c40c296c4d774fdcd33add26d361dd2adc994635eL2-R15) [[2]](diffhunk://#diff-a1264851df883ea8a16a191c40c296c4d774fdcd33add26d361dd2adc994635eL89-R90)
* The unit test workflow in `.github/workflows/unit_tests.yml` was updated to exclude integration tests from the default test run by adding `-m "not integration"` to the pytest command.

**CI/CD pipeline enhancements:**

* The build and deploy workflow in `.github/workflows/deploy-gcp.yml` was refactored to rename the `build-backend` job to `build`, update the integration test command to use `pytest` with the correct marker and path, and add a new step to build the frontend Docker image with appropriate build arguments. [[1]](diffhunk://#diff-57ed3056e7a373d410a7264b760a8041bc157def448e2e468276b2f9d3b6ba79L26-R26) [[2]](diffhunk://#diff-57ed3056e7a373d410a7264b760a8041bc157def448e2e468276b2f9d3b6ba79L93-R93) [[3]](diffhunk://#diff-57ed3056e7a373d410a7264b760a8041bc157def448e2e468276b2f9d3b6ba79R141-R159)

**Code and documentation organization:**

* Added a module docstring to `tender_tales/tests/mcp_server/__init__.py` for clarity.

**Frontend robustness:**

* Added a defensive check in `ui/src/app/kadal/page.tsx` to throw an error if map bounds cannot be obtained, improving frontend error handling.