### PR TITLE
Remove reference to Kadal internal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,14 @@
-# Tender Tales Platform
+# Tender Tales Inc. Website
 
-----------------------------------------------------------------------------------------
+This repository contains the website for Tender Tales Inc., an environmental technology company dedicated to ecosystem preservation and monitoring.
 
-[![code checks](https://github.com/tender-tales/platform/actions/workflows/code_checks.yml/badge.svg)](https://github.com/tender-tales/platform/actions/workflows/code_checks.yml)
-[![unit tests](https://github.com/tender-tales/platform/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/tender-tales/platform/actions/workflows/unit_tests.yml)
-[![docs](https://github.com/tender-tales/platform/actions/workflows/docs.yml/badge.svg)](https://github.com/tender-tales/platform/actions/workflows/docs.yml)
-[![codecov](https://codecov.io/github/tender-tales/platform/graph/badge.svg?token=83MYFZ3UPA)](https://codecov.io/github/tender-tales/platform)
-![GitHub License](https://img.shields.io/github/license/tender-tales/platform)
+## About Tender Tales Inc.
 
-A full-stack platform for satellite data analysis and similarity mapping using Google Earth Engine.
+Tender Tales Inc. is focused on protecting vulnerable ecosystems and preserving the rich fabric of biodiversity on which all life depends. The company uses advanced technologies including Google Earth Engine and AI to visualize and analyze environmental transformations caused by human activity.
 
-## Architecture
+Our services include:
+- Conservation partnerships
+- Pro bono environmental consulting
+- Satellite-based change detection through our Kadal platform
 
-- **Frontend (`ui/`)**: Next.js application with TypeScript and Tailwind CSS
-- **Backend (`tender_tales/`)**: Python FastAPI backend with Google Earth Engine integration
-- **Docker**: Containerized with development and production configurations
-
-## Quick Start
-
-### Development
-
-1. Set up environment:
-```bash
-cp .env.development .env
-# Edit .env with your Google Earth Engine credentials
-```
-
-2. Run with Docker Compose:
-```bash
-docker compose --env-file .env.development -f docker-compose.dev.yml up backend-dev
-# In another terminal for frontend:
-docker compose --env-file .env.development -f docker-compose.dev.yml --profile frontend up frontend-dev
-```
-
-
-## Environment Variables
-
-### Required
-- `EARTH_ENGINE_PROJECT_ID` - Your Google Earth Engine project ID
-- `GOOGLE_APPLICATION_CREDENTIALS` - Path to your service account key file
-
-### Optional
-- `FRONTEND_PORT` - Frontend port (default: 3000)
-- `BACKEND_PORT` - Backend port (default: 8000)
-- `DEBUG` - Enable debug mode (default: false)
-
-
-## Google Earth Engine Setup
-
-1. Create a Google Cloud Project
-2. Enable the Earth Engine API
-3. Create a service account and download the key file
-4. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to the key file
-5. Set the `EARTH_ENGINE_PROJECT_ID` environment variable
-
-## Development Commands
-
-### Frontend (ui/)
-```bash
-cd ui/
-npm install
-npm run dev
-npm run build
-npm run lint
-```
-
-### Backend (tender_tales/)
-```bash
-cd tender_tales/
-uv sync --dev
-uv run uvicorn api.main:app --reload
-uv run pytest
-```
+Visit us at [tendertales.ca](https://tendertales.ca)

--- a/ui/src/components/footer.tsx
+++ b/ui/src/components/footer.tsx
@@ -86,16 +86,6 @@ export default function Footer() {
                   Kadal
                 </a>
               </li>
-              <li>
-                <a
-                  href="https://tender-tales.github.io/platform/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-gray-400 hover:text-white transition-colors duration-200"
-                >
-                  Documentation
-                </a>
-              </li>
             </ul>
           </div>
 


### PR DESCRIPTION
This pull request updates the public-facing content and navigation for the Tender Tales Inc. website. The main changes focus on revising the `README.md` to better describe the company's mission and services, and simplifying the website footer by removing the documentation link.

Content and documentation updates:

* Rewrote `README.md` to focus on Tender Tales Inc.'s mission, services, and company overview, removing technical setup, architecture details, and development instructions.

UI/navigation changes:

* Removed the "Documentation" link from the website footer in `footer.tsx` to streamline navigation.